### PR TITLE
Fix crash with TankPublishedFile without thumbnails

### DIFF
--- a/python/tk_mari_projectmanager/publish_list_view.py
+++ b/python/tk_mari_projectmanager/publish_list_view.py
@@ -132,7 +132,8 @@ class PublishListView(browser_widget.BrowserWidget):
             entity_name = sg_publish.get("entity", {}).get("name")
             task_name = sg_publish.get("task.Task.content")
             
-            list_item.set_thumbnail(thumbnail_path)
+            if thumbnail_path:
+                list_item.set_thumbnail(thumbnail_path)
             
             line_1 = "<b>%s v%03d</b>" % (name, version)
             line_2 = "%s %s, %s" % (entity_type, entity_name, task_name)


### PR DESCRIPTION
In some case, a TankPublishedFile can not have a thumbnail uploaded. Either the entity was manually created or the studio have modified the core to prevent "placeholder" thumbnail from being uploaded, saving screen space in the web-interface. In that case, a thread in the BrowserWidget will crash.
