### PR TITLE
SG-33057 update pre commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,16 +8,19 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+default_language_version:
+    python: python3
+
 # Exclude the UI files, as they are auto-generated.
 exclude: "ui\/.*py$"
+
 # List of super useful formatters.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v5.0.0
     hooks:
     # Ensures the code is syntaxically correct
     - id: check-ast
-      language_version: python3
     # Ensures a file name will resolve on all platform
     - id: check-case-conflict
     # Checks files with the execute bit set have shebangs
@@ -31,8 +34,7 @@ repos:
     # Removes trailing whitespaces.
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
-  - repo: https://github.com/ambv/black
-    rev: 22.3.0
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
     hooks:
     - id: black
-      language_version: python3

--- a/hooks/get_project_creation_args.py
+++ b/hooks/get_project_creation_args.py
@@ -63,17 +63,17 @@ class GetArgsHook(HookBaseClass):
         # prefer uvV (UDIM) over ptex
         project_meta_options["MappingScheme"] = mari.projects.UV_OR_PTEX
         # create selection sets from face groups based on shader assignments
-        project_meta_options[
-            "CreateSelectionSets"
-        ] = mari.geo.SELECTION_GROUPS_CREATE_FROM_FACE_GROUPS
+        project_meta_options["CreateSelectionSets"] = (
+            mari.geo.SELECTION_GROUPS_CREATE_FROM_FACE_GROUPS
+        )
         # Mari 4.6 started giving a deprecation warning that this value would change it's
         # default in future versions, so we're locking it to the current
         # one.
         # Up to 4.6, the default value is documented at
         # file:///Applications/Mari4.6v4/Mari4.6v4.app/Contents/Resources/pydoc/mari.ProjectManager-class.html#create
-        project_meta_options[
-            "MergeSelectionGroupWithSameNameType"
-        ] = mari.geo.MERGESELECTIONGROUP_DO_NOT_MERGE
+        project_meta_options["MergeSelectionGroupWithSameNameType"] = (
+            mari.geo.MERGESELECTIONGROUP_DO_NOT_MERGE
+        )
         # merge nodes within file but not all geometry into a single mesh
         project_meta_options["MergeType"] = mari.geo.MERGETYPE_JUST_MERGE_NODES
 


### PR DESCRIPTION
Cleanup and update `.pre-commit-config.yaml` file:
- Update pre-commit-hooks to version `v5.0.0`
- Update black hook to version `25.1.0`
- Update black hook URL
- Use global `default_language_version` instead of individuals `language_version`

These changes are optional considering shotgunsoftware/tk-ci-tools#58. But we might want to cleanup/update the `.pre-commit-config.yaml` file every once in a while.